### PR TITLE
fix: fix not initialized variable `Automation`

### DIFF
--- a/vsatisfy/Plugin.cs
+++ b/vsatisfy/Plugin.cs
@@ -8,8 +8,6 @@ public sealed class Plugin : IDalamudPlugin
 {
     public static Config Config { get; private set; } = null!;
 
-    public clib.Services.Automation Automation { get; }
-
     private readonly WindowSystem WindowSystem = new("vsatisfy");
     private readonly MainWindow _wndMain;
     private readonly ICommandManager _cmd;
@@ -30,7 +28,6 @@ public sealed class Plugin : IDalamudPlugin
 
         clib.CLibMain.Init(dalamud, this);
         Service.Initialize(this, dalamud);
-        Automation = new();
 
         Config = new Config();
         Config.Load(dalamud.ConfigFile);

--- a/vsatisfy/Service.cs
+++ b/vsatisfy/Service.cs
@@ -30,6 +30,7 @@ public class Service
     internal static void Initialize(Plugin plugin, IDalamudPluginInterface dalamud)
     {
         Plugin = plugin;
+        Automation = new();
         dalamud.Create<Service>();
     }
 }


### PR DESCRIPTION
`Plugin.Automation` and `Service.Automation` differ, which causes null reference exception while `DrawMainTable`.