### PR TITLE
fix: fix stuck while turnin-ing

### DIFF
--- a/vsatisfy/AutoCommon.cs
+++ b/vsatisfy/AutoCommon.cs
@@ -18,7 +18,8 @@ public abstract class AutoCommon : TaskBase
             await WaitUntilSkipTalk(Game.IsSelectStringAddonActive, "WaitSelect");
             Game.SelectTurnIn();
         }
-        for (int i = 0; i < npc.RemainingTurnins(slot); ++i)
+        var turninsCount = npc.RemainingTurnins(slot);
+        for (int i = 0; i < turninsCount; ++i)
         {
             await WaitUntilSkipTalk(() => Game.IsTurnInSupplyInProgress((uint)npc.Index + 1), "WaitDialog");
             Game.TurnInSupply(slot);


### PR DESCRIPTION
When turnin the items, it will be stuck after `ceil(remaining turnin/2) + 1` turnins.

This is because `npc. RemainingTurnins` is called after each loop iteration.
